### PR TITLE
Remove old Homebrew command from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,7 @@
 [Download the latest release][download-latest] or install via Homebrew:
 
 ```sh
-# Latest homebrew:
 brew install bluesnooze
-
-# Homebrew 2.5 or below
-brew cask install bluesnooze
 ```
 
 ## About


### PR DESCRIPTION
I accidentally ran the wrong one because I didn't read closely enough. I don't think many is on a Homebrew version that old anymore so I figured it can be removed now.

Thanks for the app!